### PR TITLE
fixed bug with dimple height being incorrect

### DIFF
--- a/RBCollectionViewInfoFolderLayout/RBCollectionViewInfoFolderLayout.m
+++ b/RBCollectionViewInfoFolderLayout/RBCollectionViewInfoFolderLayout.m
@@ -429,7 +429,12 @@ NSString *const RBCollectionViewInfoFolderFolderKind = @"RBCollectionViewInfoFol
 		CGFloat deltaX = [self.deltaXInSection[@( indexPath.section )] floatValue];
 
 		CGFloat additionalHeight = 10;
-		CGFloat height = self.interItemSpacingY + additionalHeight;
+        CGFloat height = self.interItemSpacingY + additionalHeight;;
+        
+        if(height <= 10){
+            height *= 2;
+        }
+        
 		CGFloat width = (height / 3) * 5;
 
 		if (cellsPerRowInSection == 1)

--- a/RBCollectionViewInfoFolderLayout/RBCollectionViewInfoFolderLayout.m
+++ b/RBCollectionViewInfoFolderLayout/RBCollectionViewInfoFolderLayout.m
@@ -432,7 +432,7 @@ NSString *const RBCollectionViewInfoFolderFolderKind = @"RBCollectionViewInfoFol
         CGFloat height = self.interItemSpacingY + additionalHeight;;
         
         if(height <= 10){
-            height *= 2;
+            height = additionalHeight * 2;
         }
         
 		CGFloat width = (height / 3) * 5;


### PR DESCRIPTION
when the `interItemSpacingY` is set to 0 the dimple was being drawn to high because of the following line `viewRect.origin.y -= additionalHeight * 2;`
by checking if the height is smaller or equal to 10 the accurate height can be given to the dimple.

also when the `interItemSpacingY` was set to a - value the dimple wouldn't draw like supposed to. this is also fixed with the added code