### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#InfoFolderLayout
+# InfoFolderLayout
 
 A UICollectionViewLayout that uses supplemental views to display a folder below a cell that looks like the screen was split.  Mimics the pre iOS7 springboard groups visualization.  Wrote this because all of the other "folder" controls like this use a screen shot to do the splitting, but I wanted my collection view to still be functional even with the folder open.
 
@@ -101,7 +101,7 @@ Handle various suplementary view request
 }
 ```
 
-####TODO
+#### TODO
 
 - [X] Imlement decoration view that places a caret over opened item linking it to the folder
 - [X] Animate dimple decoration


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
